### PR TITLE
Fix missing "on" and "emit" methods

### DIFF
--- a/src/webrtc/PeerConnection.ts
+++ b/src/webrtc/PeerConnection.ts
@@ -97,4 +97,12 @@ export class PeerConnection extends EventEmitter {
       this.emit('addstream', stream);
     });
   }
+  
+  on(event: string | symbol, listener: (...args: any[]) => void): this {
+    return super.on(event, listener);
+  }
+
+  emit(event: string | symbol, ...args: any[]): boolean {
+    return super.emit(event, args);
+  }
 }


### PR DESCRIPTION
Add methods on, and emit from super class. 

When EventEmmiter type is not found by NPM, package returns an error saying that there is no method on and no method emit on PeerConnection Class. 
This is a workaround to the PeerConnection missing methods error.